### PR TITLE
fix(cmake): correct include paths for interface target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,10 @@ endif()
 
 add_subdirectory(src/core)
 add_library(sqlinq INTERFACE)
+target_include_directories(sqlinq INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
 target_link_libraries(sqlinq INTERFACE
   sqlinq-core
   ${SQLINQ_BACKEND_LIBS}

--- a/src/backend/mysql/CMakeLists.txt
+++ b/src/backend/mysql/CMakeLists.txt
@@ -38,7 +38,8 @@ add_library(mysql-backend
 )
 
 target_include_directories(mysql-backend PUBLIC
-  ${CMAKE_CURRENT_SOURCE_DIR}/include
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
 )
 
 target_link_libraries(mysql-backend

--- a/src/backend/sqlite/CMakeLists.txt
+++ b/src/backend/sqlite/CMakeLists.txt
@@ -24,7 +24,8 @@ add_library(sqlite-backend
 )
 
 target_include_directories(sqlite-backend PUBLIC
-  ${CMAKE_CURRENT_SOURCE_DIR}/include
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
 )
 
 target_link_libraries(sqlite-backend

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -5,7 +5,8 @@ add_library(sqlinq-core
 )
 
 target_include_directories(sqlinq-core PUBLIC
-  ${CMAKE_SOURCE_DIR}/include
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../include>
+  $<INSTALL_INTERFACE:include>
 )
 
 target_compile_features(sqlinq-core PUBLIC cxx_std_20)


### PR DESCRIPTION
Previously include directories were set using CMAKE_SOURCE_DIR, which caused issues when using the library as a submodule. Now sqlinq and its components expose include/ properly via BUILD_INTERFACE and INSTALL_INTERFACE